### PR TITLE
Add demo mode option

### DIFF
--- a/ios/GlucoScope/Data/DataSourceService.swift
+++ b/ios/GlucoScope/Data/DataSourceService.swift
@@ -79,4 +79,23 @@ class DataSourceService: ObservableObject {
         datasource = nil
         prefences.connection = nil
     }
+
+    // MARK: - Demo mode
+
+    /// Returns `true` when the current datasource is a ``DemoDataSource``.
+    var isDemoMode: Bool {
+        datasource is DemoDataSource
+    }
+
+    /// Start the demo mode by using a ``DemoDataSource`` as datasource.
+    func startDemoMode() {
+        logger.debug("Starting demo mode")
+        datasource = DemoDataSource()
+    }
+
+    /// Stop demo mode and remove any datasource so onboarding restarts.
+    func stopDemoMode() {
+        logger.debug("Stopping demo mode")
+        datasource = nil
+    }
 }

--- a/ios/GlucoScope/Data/DemoDataSource.swift
+++ b/ios/GlucoScope/Data/DemoDataSource.swift
@@ -1,0 +1,31 @@
+import Foundation
+import os
+
+/// Simple datasource used for demo mode. It generates random but slowly varying
+/// glucose values and always reports a successful connection.
+class DemoDataSource: DataSource {
+    private let logger = Logger.new("datasource.demo")
+    private var lastValue: Double = 5.5
+
+    func testConnection() async throws -> Bool {
+        // Demo mode is always "connected"
+        true
+    }
+
+    func getLatestEntries(hours: Int, window: Int) async throws -> [GlucoseMeasurement] {
+        let count = max(1, hours * 60 / max(1, window))
+        let interval = Double(window * 60)
+        let now = Date().timeIntervalSince1970
+
+        var measurements: [GlucoseMeasurement] = []
+        for i in 0..<count {
+            // Keep the value within realistic boundaries and slowly vary
+            lastValue += Double.random(in: -0.3...0.3)
+            lastValue = min(max(lastValue, 3.5), 10.0)
+            let time = now - Double(count - i) * interval
+            measurements.append(GlucoseMeasurement(time: time, value: lastValue))
+        }
+        logger.trace("Generated \(measurements.count) demo values")
+        return measurements
+    }
+}

--- a/ios/GlucoScope/View/Configuration/ConnectionSettingsView.swift
+++ b/ios/GlucoScope/View/Configuration/ConnectionSettingsView.swift
@@ -3,15 +3,23 @@ import SwiftUI
 struct ConnectionSettingsView: View {
     @EnvironmentObject var prefs: PreferenceService
     @EnvironmentObject var dataService: DataSourceService
+    @Environment(\.presentationMode) var presentationMode
 
     var body: some View {
         let configuration = dataService.configuration
 
         RotatingConfigurationView(title: "Connection", header: ThemedServerSettingsGraphic.init) {
-            ConnectionConfigurationEditor(configuration: configuration) { conf in
-                self.dataService.saveConfiguration(conf)
-            } onReset: {
-                dataService.clearConfiguration()
+            if dataService.isDemoMode {
+                Button("Setup GlucoScope") {
+                    dataService.stopDemoMode()
+                    presentationMode.wrappedValue.dismiss()
+                }
+            } else {
+                ConnectionConfigurationEditor(configuration: configuration) { conf in
+                    self.dataService.saveConfiguration(conf)
+                } onReset: {
+                    dataService.clearConfiguration()
+                }
             }
         }
     }

--- a/ios/GlucoScope/View/Onboarding/IntroView.swift
+++ b/ios/GlucoScope/View/Onboarding/IntroView.swift
@@ -2,6 +2,8 @@ import SwiftUI
 
 struct IntroView: View {
     @EnvironmentObject private var prefs: PreferenceService
+    @EnvironmentObject private var dataService: DataSourceService
+    @State private var showDemoAlert = false
 
     var body: some View {
         ThemedScreen {
@@ -30,6 +32,10 @@ struct IntroView: View {
                         .padding(.vertical, 8)
 
                         ThemedNavigationButton("Get started", ConnectionTypeView())
+                        Button("Demo mode") {
+                            showDemoAlert = true
+                        }
+                        .font(.footnote)
                     }
                     .padding(16)
                 }
@@ -48,6 +54,12 @@ struct IntroView: View {
             }
         }
         .navigationBarTitleDisplayMode(.inline)
+        .alert("Start demo mode?", isPresented: $showDemoAlert) {
+            Button("Start") { dataService.startDemoMode() }
+            Button("Cancel", role: .cancel) { }
+        } message: {
+            Text("Demo mode uses fake data. You can setup GlucoScope later from Settings.")
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- add `DemoDataSource` for generating fake data
- enable demo mode through new functions in `DataSourceService`
- show demo mode button in onboarding intro
- show Setup GlucoScope button on connection settings when demo mode is active

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `xcodebuild -list -project ios/GlucoScope.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e3cb6d860832f9bba9c920742a649